### PR TITLE
Bug: Set timezone on scrubbed_at field to fix test

### DIFF
--- a/src/main/resources/db/migration/V6__fix_scrubbed_at_timestamptz.sql
+++ b/src/main/resources/db/migration/V6__fix_scrubbed_at_timestamptz.sql
@@ -1,0 +1,2 @@
+ALTER TABLE event
+    ALTER COLUMN scrubbed_at TYPE timestamptz USING scrubbed_at AT TIME ZONE 'UTC';


### PR DESCRIPTION
Test failing was:
```
org.opentest4j.AssertionFailedError:
expected: 2024-01-04T13:00:00.000 (java.sql.Timestamp)
 but was: 2024-01-04T12:00:00.000 (java.sql.Timestamp)
	at no.novari.flyt.history.ScheduledErrorScrubServiceTest.scrubs old events in batches and ignores already scrubbed and new events(ScheduledErrorScrubServiceTest.kt:105)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```