### PR TITLE
FFS-2041: Opprette instance-error-topic og ny lytter i history-service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.11.0")
 
     implementation("no.novari:flyt-web-resource-server:3.1.0")
-    implementation("no.novari:flyt-kafka:7.0.0")
+    implementation("no.novari:flyt-kafka:7.1.0")
 
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")

--- a/src/main/kotlin/no/novari/flyt/history/kafka/EventListenerConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/history/kafka/EventListenerConfiguration.kt
@@ -9,6 +9,8 @@ import no.novari.flyt.history.repository.entities.EventEntity
 import no.novari.flyt.kafka.instanceflow.consuming.InstanceFlowListenerFactoryService
 import no.novari.flyt.kafka.model.Error
 import no.novari.flyt.kafka.model.ErrorCollection
+import no.novari.flyt.kafka.model.InstanceErrorEvent
+import no.novari.flyt.kafka.model.InstanceErrorOrigin
 import no.novari.kafka.OriginHeaderProducerInterceptor
 import no.novari.kafka.consuming.ErrorHandlerConfiguration
 import no.novari.kafka.consuming.ErrorHandlerFactory
@@ -137,6 +139,57 @@ class EventListenerConfiguration(
                 ),
             ).createContainer(createErrorEventTopicNameParameters(eventCategory.eventName))
     }
+
+    @Bean
+    fun instanceErrorListener(): ConcurrentMessageListenerContainer<String, InstanceErrorEvent> {
+        return instanceFlowListenerFactoryService
+            .createRecordListenerContainerFactory(
+                InstanceErrorEvent::class.java,
+                { instanceFlowConsumerRecord ->
+                    val event = instanceFlowConsumerRecord.consumerRecord.value()
+                    val eventCategory = event.name.toEventCategory()
+                    eventRepository.save(
+                        EventEntity(
+                            instanceFlowHeaders =
+                                instanceFlowHeadersMappingService.toEmbeddable(
+                                    instanceFlowConsumerRecord.instanceFlowHeaders,
+                                ),
+                            name = eventCategory.eventName,
+                            type = EventType.ERROR,
+                            timestamp =
+                                Instant
+                                    .ofEpochMilli(instanceFlowConsumerRecord.consumerRecord.timestamp())
+                                    .atOffset(ZoneOffset.UTC),
+                            errors = mapToErrorEntities(event.errors),
+                            applicationId = getApplicationId(instanceFlowConsumerRecord.consumerRecord.headers()),
+                        ),
+                    )
+                },
+                ListenerConfiguration
+                    .stepBuilder()
+                    .groupIdApplicationDefault()
+                    .maxPollRecordsKafkaDefault()
+                    .maxPollIntervalKafkaDefault()
+                    .continueFromPreviousOffsetOnAssignment()
+                    .build(),
+                errorHandlerFactory.createErrorHandler(
+                    ErrorHandlerConfiguration
+                        .stepBuilder<InstanceErrorEvent>()
+                        .noRetries()
+                        .skipFailedRecords()
+                        .build(),
+                ),
+            ).createContainer(createErrorEventTopicNameParameters("instance-error"))
+    }
+
+    private fun InstanceErrorOrigin.toEventCategory(): EventCategory =
+        when (this) {
+            InstanceErrorOrigin.RECEIVAL -> EventCategory.INSTANCE_RECEIVAL_ERROR
+            InstanceErrorOrigin.REGISTRATION -> EventCategory.INSTANCE_REGISTRATION_ERROR
+            InstanceErrorOrigin.RETRY_REQUEST -> EventCategory.INSTANCE_RETRY_REQUEST_ERROR
+            InstanceErrorOrigin.MAPPING -> EventCategory.INSTANCE_MAPPING_ERROR
+            InstanceErrorOrigin.DISPATCHING -> EventCategory.INSTANCE_DISPATCHING_ERROR
+        }
 
     private fun mapToErrorEntities(errorCollection: ErrorCollection): MutableCollection<ErrorEntity> {
         return errorCollection.errors

--- a/src/main/kotlin/no/novari/flyt/history/kafka/InstanceErrorTopicConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/history/kafka/InstanceErrorTopicConfiguration.kt
@@ -1,0 +1,38 @@
+package no.novari.flyt.history.kafka
+
+import no.novari.kafka.topic.ErrorEventTopicService
+import no.novari.kafka.topic.configuration.EventCleanupFrequency
+import no.novari.kafka.topic.configuration.EventTopicConfiguration
+import no.novari.kafka.topic.name.ErrorEventTopicNameParameters
+import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+@Configuration
+class InstanceErrorTopicConfiguration(
+    errorEventTopicService: ErrorEventTopicService,
+    @Value("\${novari.flyt.history-service.kafka.topic.instance-processing-events-retention-time}")
+    retentionTime: Duration,
+) {
+    init {
+        errorEventTopicService.createOrModifyTopic(
+            ErrorEventTopicNameParameters
+                .builder()
+                .errorEventName("instance-error")
+                .topicNamePrefixParameters(
+                    TopicNamePrefixParameters
+                        .stepBuilder()
+                        .orgIdApplicationDefault()
+                        .domainContextApplicationDefault()
+                        .build(),
+                ).build(),
+            EventTopicConfiguration
+                .stepBuilder()
+                .partitions(1)
+                .retentionTime(retentionTime)
+                .cleanupFrequency(EventCleanupFrequency.NORMAL)
+                .build(),
+        )
+    }
+}

--- a/src/test/kotlin/no/novari/flyt/history/kafka/InstanceErrorListenerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/history/kafka/InstanceErrorListenerTest.kt
@@ -1,0 +1,188 @@
+package no.novari.flyt.history.kafka
+
+import no.novari.flyt.history.mapping.InstanceFlowHeadersMappingService
+import no.novari.flyt.history.model.event.EventCategory
+import no.novari.flyt.history.model.event.EventType
+import no.novari.flyt.history.repository.EventRepository
+import no.novari.flyt.kafka.instanceflow.consuming.InstanceFlowConsumerRecord
+import no.novari.flyt.kafka.instanceflow.consuming.InstanceFlowListenerFactoryService
+import no.novari.flyt.kafka.instanceflow.headers.InstanceFlowHeaders
+import no.novari.flyt.kafka.model.ErrorCollection
+import no.novari.flyt.kafka.model.InstanceErrorEvent
+import no.novari.flyt.kafka.model.InstanceErrorOrigin
+import no.novari.kafka.OriginHeaderProducerInterceptor
+import no.novari.kafka.consuming.ErrorHandlerConfiguration
+import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactory
+import no.novari.kafka.topic.name.ErrorEventTopicNameParameters
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.apache.kafka.common.record.TimestampType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.util.unit.DataSize
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.Optional
+import java.util.UUID
+import java.util.function.Consumer
+
+@Testcontainers(disabledWithoutDocker = true)
+@DataJpaTest(showSql = false)
+@Import(InstanceFlowHeadersMappingService::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class InstanceErrorListenerTest {
+    @Autowired
+    lateinit var eventRepository: EventRepository
+
+    @Autowired
+    lateinit var instanceFlowHeadersMappingService: InstanceFlowHeadersMappingService
+
+    private lateinit var listener: Consumer<InstanceFlowConsumerRecord<InstanceErrorEvent>>
+
+    @BeforeEach
+    fun setUp() {
+        eventRepository.deleteAll()
+
+        val instanceFlowListenerFactoryService: InstanceFlowListenerFactoryService = mock()
+        val errorHandlerFactory: ErrorHandlerFactory = mock()
+        val listenerContainerFactory: ParameterizedListenerContainerFactory<InstanceErrorEvent> = mock()
+        val listenerContainer: ConcurrentMessageListenerContainer<String, InstanceErrorEvent> = mock()
+        val errorHandler: DefaultErrorHandler = mock()
+
+        val listenerCaptor = argumentCaptor<Consumer<InstanceFlowConsumerRecord<InstanceErrorEvent>>>()
+
+        whenever(
+            errorHandlerFactory.createErrorHandler(any<ErrorHandlerConfiguration<InstanceErrorEvent>>()),
+        ).thenReturn(errorHandler)
+        whenever(
+            instanceFlowListenerFactoryService.createRecordListenerContainerFactory(
+                any(),
+                listenerCaptor.capture(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(listenerContainerFactory)
+        whenever(listenerContainerFactory.createContainer(any<ErrorEventTopicNameParameters>()))
+            .thenReturn(listenerContainer)
+
+        EventListenerConfiguration(
+            eventRepository = eventRepository,
+            instanceFlowListenerFactoryService = instanceFlowListenerFactoryService,
+            instanceFlowHeadersMappingService = instanceFlowHeadersMappingService,
+            errorHandlerFactory = errorHandlerFactory,
+            beanFactory = mock<ConfigurableListableBeanFactory>(),
+        ).instanceErrorListener()
+
+        listener = listenerCaptor.firstValue
+    }
+
+    @ParameterizedTest
+    @EnumSource(InstanceErrorOrigin::class)
+    fun `listener persists EventEntity with correct name for each InstanceErrorOrigin`(origin: InstanceErrorOrigin) {
+        val expectedCategory = expectedCategory(origin)
+        val errors =
+            ErrorCollection(
+                listOf(
+                    no.novari.flyt.kafka.model
+                        .Error("test-error", mapOf("key" to "val")),
+                ),
+            )
+        val event = InstanceErrorEvent(name = origin, errors = errors)
+
+        listener.accept(instanceErrorConsumerRecord(event))
+
+        val saved = eventRepository.findAll()
+        assertThat(saved).hasSize(1)
+        val entity = saved.single()
+        assertThat(entity.name).isEqualTo(expectedCategory.eventName)
+        assertThat(entity.type).isEqualTo(EventType.ERROR)
+        assertThat(entity.errors).hasSize(1)
+        assertThat(entity.errors.first().errorCode).isEqualTo("test-error")
+    }
+
+    private fun expectedCategory(origin: InstanceErrorOrigin): EventCategory =
+        when (origin) {
+            InstanceErrorOrigin.RECEIVAL -> EventCategory.INSTANCE_RECEIVAL_ERROR
+            InstanceErrorOrigin.REGISTRATION -> EventCategory.INSTANCE_REGISTRATION_ERROR
+            InstanceErrorOrigin.RETRY_REQUEST -> EventCategory.INSTANCE_RETRY_REQUEST_ERROR
+            InstanceErrorOrigin.MAPPING -> EventCategory.INSTANCE_MAPPING_ERROR
+            InstanceErrorOrigin.DISPATCHING -> EventCategory.INSTANCE_DISPATCHING_ERROR
+        }
+
+    private fun instanceErrorConsumerRecord(event: InstanceErrorEvent): InstanceFlowConsumerRecord<InstanceErrorEvent> {
+        val instanceFlowHeaders =
+            InstanceFlowHeaders
+                .builder()
+                .sourceApplicationId(1L)
+                .sourceApplicationIntegrationId("sa-integration-1")
+                .sourceApplicationInstanceId("sa-instance-1")
+                .correlationId(UUID.randomUUID())
+                .integrationId(100L)
+                .build()
+        val kafkaHeaders = RecordHeaders()
+        kafkaHeaders.add(OriginHeaderProducerInterceptor.ORIGIN_APPLICATION_ID_RECORD_HEADER, "test-app".toByteArray())
+        val consumerRecord =
+            ConsumerRecord(
+                "instance-error",
+                0,
+                0L,
+                0L,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                "key",
+                event,
+                kafkaHeaders,
+                Optional.empty(),
+            )
+        return InstanceFlowConsumerRecord
+            .builder<InstanceErrorEvent>()
+            .instanceFlowHeaders(instanceFlowHeaders)
+            .consumerRecord(consumerRecord)
+            .build()
+    }
+
+    companion object {
+        @JvmField
+        @Container
+        val postgreSQLContainer: PostgreSQLContainer<*> =
+            PostgreSQLContainer("postgres:17")
+                .withUrlParam("reWriteBatchedInserts", "true")
+                .withCreateContainerCmdModifier { createContainerCmd ->
+                    requireNotNull(createContainerCmd.hostConfig)
+                        .withCpuCount(2L)
+                        .withMemory(DataSize.ofGigabytes(8).toBytes())
+                }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun postgreSQLProperties(registry: DynamicPropertyRegistry) {
+            postgreSQLContainer.start()
+            registry.add("fint.database.url", postgreSQLContainer::getJdbcUrl)
+            registry.add("fint.database.username", postgreSQLContainer::getUsername)
+            registry.add("fint.database.password", postgreSQLContainer::getPassword)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Bumper `flyt-kafka` fra `7.0.0` til `7.1.0` for å få tilgang til `InstanceErrorEvent` og `InstanceErrorOrigin`
- Ny `InstanceErrorTopicConfiguration` oppretter det felles `instance-error`-topicet med samme konfigurasjon (partisjoner, oppbevaringstid, cleanup-frekvens) som eksisterende feil-topics. Kode-kommentar forklarer avviket fra produsent-eier-prinsippet — topicet eies av history-service fordi det er eneste konsument og har fem produsenter
- Ny `instanceErrorListener`-bean i `EventListenerConfiguration` lytter på `instance-error` og konsumerer `InstanceErrorEvent`
- Privat extension `InstanceErrorOrigin.toEventCategory()` mapper alle fem opphav (`RECEIVAL`, `REGISTRATION`, `RETRY_REQUEST`, `MAPPING`, `DISPATCHING`) til tilsvarende `EventCategory`
- Lagrer `EventEntity` identisk med de fem eksisterende feil-lytterne — `name`, `type` og feil-entiteter er uendret, slik at `/api/intern/instance-flow-tracking/events` returnerer identisk respons
- De fem eksisterende lytterne beholdes uendret (konsument-først-strategi fra [FFS-2039](https://novari-iks.atlassian.net/browse/FFS-2039))
- Parametrisert test i `InstanceErrorListenerTest` verifiserer korrekt `EventEntity`-lagring for alle fem `InstanceErrorOrigin`-verdier

Relatert: [FFS-2041](https://novari-iks.atlassian.net/browse/FFS-2041) · Epic: [FFS-1952](https://novari-iks.atlassian.net/browse/FFS-1952)

[FFS-2039]: https://novari-iks.atlassian.net/browse/FFS-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ