### PR TITLE
FFS-2169: Header-basert ingress-routing for Bearer/M2M

### DIFF
--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -27,10 +27,18 @@ spec:
     hostname: flyt.vigoiks.no
     basePath: ""
   ingress:
-    enabled: true
-    basePath: /api/intern/instance-flow-tracking
-    middlewares:
-      - fint-flyt-auth-forward-sso
+    routes:
+      # Bearer/M2M: requests som allerede bærer en Authorization-header rutes utenom
+      # SSO-middlewaren og treffer resource-serveren direkte.
+      - host: flyt.vigoiks.no
+        path: /api/intern/instance-flow-tracking
+        headers:
+          Authorization: "re:.+"
+      # Cookie/nettleser: alt annet håndteres av SSO-middlewaren (cookie -> Bearer).
+      - host: flyt.vigoiks.no
+        path: /api/intern/instance-flow-tracking
+        middlewares:
+          - fint-flyt-auth-forward-sso
   env:
     - name: JAVA_TOOL_OPTIONS
       value: '-XX:+ExitOnOutOfMemoryError -Xmx768M -Xms700M'

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/afk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/afk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/afk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/afk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/agderfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/agderfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/agderfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/agderfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/bfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/bfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bym-oslo-kommune-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bym-oslo-kommune-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ffk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ffk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ffk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ffk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "fintlabs.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/fintlabs-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/fintlabs-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/innlandetfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/innlandetfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/innlandetfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/innlandetfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "mrfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/mrfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/mrfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "nfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/nfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/nfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ofk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ofk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ofk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ofk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/rogfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/rogfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/rogfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/rogfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/telemarkfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/telemarkfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/telemarkfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/telemarkfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/tromsfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/tromsfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/tromsfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/tromsfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/trondelagfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/trondelagfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/trondelagfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/trondelagfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vestfoldfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vestfoldfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vestfoldfylke-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vestfoldfylke-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vlfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vlfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vlfk-no/api/intern/instance-flow-tracking"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vlfk-no/api/intern/instance-flow-tracking"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "$ORG_ID"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "$INGRESS_BASE_PATH"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "$INGRESS_BASE_PATH"
       - op: add
         path: "/spec/env/-"


### PR DESCRIPTION
## Summary
- Bytt `kustomize/base/flais.yaml` fra legacy `ingress` (`enabled`/`basePath`/topp-nivå `middlewares`) til flaiserator `routes`-form med to ruter på samme host og path: én uten middleware som treffes når requesten allerede har en `Authorization`-header (`headers: Authorization: "re:.+"`) for M2M og omskrevet frontend, og én fallback med `fint-flyt-auth-forward-sso` for dagens cookie-baserte SSO-flyt.
- Oppdater `kustomize/templates/overlay.yaml.tpl` til å patche `/spec/ingress/routes/0/path` og `/1/path` (samme verdi) i stedet for `/spec/ingress/basePath`.
- Regenerer alle 27 overlays via `script/render-overlay.sh` (ingen manuelt hardkodede overlays).
- Ren ingress-konfig — ingen backend-kodeendring, siden tjenesten allerede validerer JWT direkte som OAuth2 resource server.

Del av epic https://novari-iks.atlassian.net/browse/FFS-2164, samme mønster som verifisert i pilot i fint-flyt-discovery-service (FFS-2121/FFS-2168).

Verifisert: `kubectl kustomize` bygger feilfritt for samtlige 27 overlays; spotsjekket at begge ruter rendrer med riktig per-tenant path.