### PR TITLE
FFS-2186: Migrer history-service til batch-autorisering

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Validation failures respond with 422 Unprocessable Entity using the shared forma
 
 ## Configuration
 
-The service layers Spring profiles (flyt-kafka, flyt-logging, flyt-web-resource-server, flyt-postgres) and exposes these key properties:
+The service layers Spring profiles (flyt-kafka, flyt-logging, flyt-web-resource-server,
+flyt-authorization-client, flyt-postgres) and exposes these key properties:
 
 | Property                                                                                   | Description                                                                                |
 |--------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
@@ -100,6 +101,7 @@ The service layers Spring profiles (flyt-kafka, flyt-logging, flyt-web-resource-
 | fint.database.url, fint.database.username, fint.database.password                          | PostgreSQL JDBC connection supplied via secrets/environment.                               |
 | spring.kafka.bootstrap-servers                                                             | Kafka cluster endpoint; application-local-staging.yaml defaults to localhost:9092.         |
 | spring.security.oauth2.resourceserver.jwt.issuer-uri                                       | Authority used for JWT validation.                                                         |
+| fint.flyt.authorization.sso.client-id / client-secret                                       | OAuth2 client credentials for authorization-service.                                      |
 | no.novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json | Mapping of org IDs to roles that may call the internal API.                                |
 | server.max-http-request-header-size                                                        | Raised to 40KB to handle large JWTs.                                                       |
 | spring.jackson.time-zone                                                                   | Forces JSON serialization to UTC.                                                          |
@@ -132,7 +134,7 @@ Flyway migrations run at startup; ensure the configured schema exists (local pro
 ## Security
 
 - Runs as an OAuth2 resource server (JWT) and only exposes internal APIs guarded by novari.flyt.web-resource-server.security.api.internal.
-- AuthorizationService relies on UserAuthorizationService to intersect requested source applications with caller entitlements before returning data or executing manual actions.
+- AuthorizationService relies on UserAuthorizationService to authorize requested source-application candidates over OAuth2-protected HTTP before returning data or executing manual actions. Unfiltered lists first obtain distinct candidates from the event database.
 - Manual event endpoints validate payloads, re-check authorization, ensure the latest status is ERROR, and return 404/400 for inconsistent histories.
 
 ## Observability & Operations

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.3")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
     implementation("no.novari:flyt-kafka:7.2.0")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.3")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
+    implementation("no.novari:flyt-web-resource-server:4.0.0")
     implementation("no.novari:flyt-kafka:7.2.0")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.3")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
     implementation("no.novari:flyt-kafka:7.2.0")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.3")
 
-    implementation("no.novari:flyt-web-resource-server:3.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
     implementation("no.novari:flyt-kafka:7.2.0")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 

--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -42,6 +42,16 @@ spec:
   env:
     - name: JAVA_TOOL_OPTIONS
       value: '-XX:+ExitOnOutOfMemoryError -Xmx768M -Xms700M'
+    - name: fint.flyt.authorization.sso.client-id
+      valueFrom:
+        secretKeyRef:
+          name: fint-flyt-authorization-oauth2-client
+          key: fint.sso.client-id
+    - name: fint.flyt.authorization.sso.client-secret
+      valueFrom:
+        secretKeyRef:
+          name: fint-flyt-authorization-oauth2-client
+          key: fint.sso.client-secret
   resources:
     limits:
       memory: "1024Mi"

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flais.yaml
+  - oauth2-authorization-client.yaml

--- a/kustomize/base/oauth2-authorization-client.yaml
+++ b/kustomize/base/oauth2-authorization-client.yaml
@@ -1,0 +1,7 @@
+apiVersion: "fintlabs.no/v1alpha1"
+kind: NamOAuthClientApplicationResource
+metadata:
+  name: fint-flyt-authorization-oauth2-client
+spec:
+  grantTypes:
+    - client_credentials

--- a/src/main/kotlin/no/novari/flyt/history/AuthorizationService.kt
+++ b/src/main/kotlin/no/novari/flyt/history/AuthorizationService.kt
@@ -15,20 +15,12 @@ class AuthorizationService(
         userAuthorizationService.checkIfUserHasAccessToSourceApplication(authentication, sourceApplicationId)
     }
 
-    fun getUserAuthorizedSourceApplicationIds(authentication: Authentication): Set<Long> {
-        return userAuthorizationService.getUserAuthorizedSourceApplicationIds(authentication).toSortedSet()
-    }
-
-    fun getIntersectionWithAuthorizedSourceApplicationIds(
+    fun getUserAuthorizedSourceApplicationIds(
         authentication: Authentication,
-        sourceApplicationIds: Collection<Long>?,
+        sourceApplicationIds: Set<Long>,
     ): Set<Long> {
-        val userAuthorizedSourceApplicationIds = getUserAuthorizedSourceApplicationIds(authentication)
-        if (userAuthorizedSourceApplicationIds.isEmpty()) {
-            return userAuthorizedSourceApplicationIds
-        }
-
-        return sourceApplicationIds?.let { userAuthorizedSourceApplicationIds intersect it.toSet() }
-            ?: userAuthorizedSourceApplicationIds
+        return userAuthorizationService
+            .getUserAuthorizedSourceApplicationIds(authentication, sourceApplicationIds)
+            .toSortedSet()
     }
 }

--- a/src/main/kotlin/no/novari/flyt/history/EventService.kt
+++ b/src/main/kotlin/no/novari/flyt/history/EventService.kt
@@ -32,6 +32,8 @@ class EventService(
     private val integrationStatisticsFilterMappingService: IntegrationStatisticsFilterMappingService,
     private val eventCategorizationService: EventCategorizationService,
 ) {
+    fun findDistinctSourceApplicationIds(): Set<Long> = eventRepository.findDistinctSourceApplicationIds()
+
     fun save(event: Event): Event {
         return eventMappingService.toEvent(
             eventRepository.save(eventMappingService.toEventEntity(event)),

--- a/src/main/kotlin/no/novari/flyt/history/HistoryController.kt
+++ b/src/main/kotlin/no/novari/flyt/history/HistoryController.kt
@@ -38,7 +38,10 @@ class HistoryController(
     @GetMapping("statistics/total")
     fun getOverallStatistics(authentication: Authentication): InstanceStatisticsProjection {
         val userAuthorizedSourceApplicationIds =
-            authorizationService.getUserAuthorizedSourceApplicationIds(authentication)
+            authorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                eventService.findDistinctSourceApplicationIds(),
+            )
 
         return eventService.getStatistics(userAuthorizedSourceApplicationIds)
     }
@@ -50,7 +53,7 @@ class HistoryController(
         pageable: Pageable,
     ): IntegrationStatisticsResponse {
         val intersectionOfAuthorizedAndFilterSourceApplicationIds =
-            authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(
+            getAuthorizedSourceApplicationIds(
                 authentication,
                 integrationStatisticsFilter.sourceApplicationIds,
             )
@@ -91,7 +94,7 @@ class HistoryController(
         validate(instanceFlowSummariesFilter)
 
         val intersectionOfAuthorizedAndFilterSourceApplicationIds =
-            authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(
+            getAuthorizedSourceApplicationIds(
                 authentication,
                 instanceFlowSummariesFilter.sourceApplicationIds,
             )
@@ -106,6 +109,16 @@ class HistoryController(
             )
 
         return eventServiceCallFunction(filterLimitedByUserAuthorization)
+    }
+
+    private fun getAuthorizedSourceApplicationIds(
+        authentication: Authentication,
+        requestedSourceApplicationIds: Collection<Long>?,
+    ): Set<Long> {
+        return authorizationService.getUserAuthorizedSourceApplicationIds(
+            authentication,
+            requestedSourceApplicationIds?.toSet() ?: eventService.findDistinctSourceApplicationIds(),
+        )
     }
 
     @GetMapping(

--- a/src/main/kotlin/no/novari/flyt/history/repository/EventRepository.kt
+++ b/src/main/kotlin/no/novari/flyt/history/repository/EventRepository.kt
@@ -23,6 +23,15 @@ import java.time.ZoneOffset
 @Repository
 interface EventRepository : JpaRepository<EventEntity, Long> {
     @Query(
+        """
+        SELECT DISTINCT event.instanceFlowHeaders.sourceApplicationId
+        FROM EventEntity event
+        WHERE event.instanceFlowHeaders.sourceApplicationId IS NOT NULL
+        """,
+    )
+    fun findDistinctSourceApplicationIds(): Set<Long>
+
+    @Query(
         value =
             """
              SELECT  statusEvent.source_application_id             AS sourceApplicationId,

--- a/src/main/resources/application-flyt-authorization-client.yaml
+++ b/src/main/resources/application-flyt-authorization-client.yaml
@@ -1,0 +1,20 @@
+novari:
+  flyt:
+    web-resource-server:
+      security:
+        authorization:
+          base-url: 'http://fint-flyt-authorization-service:8080${server.servlet.context-path:}'
+
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          fint-idp:
+            token-uri: https://idp.felleskomponent.no/nidp/oauth/nam/token
+        registration:
+          authorization-service:
+            authorization-grant-type: client_credentials
+            client-id: ${fint.flyt.authorization.sso.client-id}
+            client-secret: ${fint.flyt.authorization.sso.client-secret}
+            provider: fint-idp

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,7 @@ spring:
       - flyt-kafka
       - flyt-logging
       - flyt-web-resource-server
+      - flyt-authorization-client
       - flyt-postgres
 
   output:

--- a/src/test/kotlin/no/novari/flyt/history/AuthorizationServiceTest.kt
+++ b/src/test/kotlin/no/novari/flyt/history/AuthorizationServiceTest.kt
@@ -19,61 +19,14 @@ class AuthorizationServiceTest {
     }
 
     @Test
-    fun `given authentication with no authorized source applications when get intersection then return empty list`() {
-        val authentication = mockAuthorizedSourceApplicationIds()
+    fun `returns the source applications authorized by the web resource server`() {
+        val authentication: Authentication = mock()
+        val candidateIds = setOf(3L, 1L, 2L)
+        whenever(userAuthorizationService.getUserAuthorizedSourceApplicationIds(authentication, candidateIds))
+            .thenReturn(setOf(2L, 1L))
 
-        val result =
-            authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(
-                authentication,
-                listOf(1L),
-            )
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `given authorized source applications and no intersecting ids then return empty list`() {
-        val authentication = mockAuthorizedSourceApplicationIds(2L)
-
-        val result =
-            authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(
-                authentication,
-                listOf(1L),
-            )
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `given authentication with same source application ids when get intersection then return intersection`() {
-        val authentication = mockAuthorizedSourceApplicationIds(1L, 2L)
-
-        val result =
-            authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(
-                authentication,
-                listOf(1L, 3L),
-            )
-
-        assertThat(result).containsExactly(1L)
-    }
-
-    @Test
-    fun `given authorized source applications and null filter then return authorized source applications`() {
-        val authentication = mockAuthorizedSourceApplicationIds(1L, 2L)
-
-        val result =
-            authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(
-                authentication,
-                null,
-            )
+        val result = authorizationService.getUserAuthorizedSourceApplicationIds(authentication, candidateIds)
 
         assertThat(result).containsExactly(1L, 2L)
-    }
-
-    private fun mockAuthorizedSourceApplicationIds(vararg sourceApplicationIds: Long): Authentication {
-        val authentication: Authentication = mock()
-        whenever(userAuthorizationService.getUserAuthorizedSourceApplicationIds(authentication))
-            .thenReturn(setOf(*sourceApplicationIds.toTypedArray()))
-        return authentication
     }
 }

--- a/src/test/kotlin/no/novari/flyt/history/HistoryControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/history/HistoryControllerTest.kt
@@ -1,0 +1,84 @@
+package no.novari.flyt.history
+
+import jakarta.validation.Validator
+import jakarta.validation.ValidatorFactory
+import no.novari.flyt.history.model.statistics.IntegrationStatisticsFilter
+import no.novari.flyt.history.repository.projections.IntegrationStatisticsProjection
+import no.novari.flyt.history.validation.ValidationErrorsFormattingService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.security.core.Authentication
+
+class HistoryControllerTest {
+    private lateinit var authorizationService: AuthorizationService
+    private lateinit var eventService: EventService
+    private lateinit var validatorFactory: ValidatorFactory
+    private lateinit var validator: Validator
+    private lateinit var controller: HistoryController
+
+    @BeforeEach
+    fun setup() {
+        authorizationService = mock()
+        eventService = mock()
+        validatorFactory = mock()
+        validator = mock()
+        whenever(validatorFactory.validator).thenReturn(validator)
+        controller =
+            HistoryController(
+                authorizationService,
+                eventService,
+                mock(),
+                validatorFactory,
+                mock<ValidationErrorsFormattingService>(),
+            )
+    }
+
+    @Test
+    fun `integration statistics authorizes database candidates before loading data`() {
+        val authentication: Authentication = mock()
+        val candidateSourceApplicationIds = setOf(1L, 2L, 3L)
+        val authorizedSourceApplicationIds = setOf(1L, 3L)
+        val filter = IntegrationStatisticsFilter.builder().build()
+        val pageable = PageRequest.of(0, 10)
+        val expected: Slice<IntegrationStatisticsProjection> =
+            SliceImpl(
+                listOf(mock()),
+                pageable,
+                false,
+            )
+
+        whenever(eventService.findDistinctSourceApplicationIds()).thenReturn(candidateSourceApplicationIds)
+        whenever(
+            authorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                candidateSourceApplicationIds,
+            ),
+        ).thenReturn(authorizedSourceApplicationIds)
+        whenever(
+            eventService.getIntegrationStatistics(
+                filter.copy(sourceApplicationIds = authorizedSourceApplicationIds),
+                pageable,
+            ),
+        ).thenReturn(expected)
+
+        val response = controller.getIntegrationStatistics(authentication, filter, pageable)
+
+        assertThat(response.content).isEqualTo(expected.content)
+        verify(eventService).findDistinctSourceApplicationIds()
+        verify(authorizationService).getUserAuthorizedSourceApplicationIds(
+            authentication,
+            candidateSourceApplicationIds,
+        )
+        verify(eventService).getIntegrationStatistics(
+            filter.copy(sourceApplicationIds = authorizedSourceApplicationIds),
+            pageable,
+        )
+    }
+}

--- a/src/test/kotlin/no/novari/flyt/history/HistoryControllerWebMvcTest.kt
+++ b/src/test/kotlin/no/novari/flyt/history/HistoryControllerWebMvcTest.kt
@@ -14,7 +14,6 @@ import no.novari.flyt.history.validation.ValidationErrorsFormattingService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -98,8 +97,14 @@ class HistoryControllerWebMvcTest {
 
     @Test
     fun `integration statistics endpoint returns stable content without slice metadata`() {
-        whenever(authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(any(), anyOrNull()))
-            .thenReturn(setOf(1L))
+        val candidateSourceApplicationIds = setOf(1L)
+        whenever(eventService.findDistinctSourceApplicationIds()).thenReturn(candidateSourceApplicationIds)
+        whenever(
+            authorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                candidateSourceApplicationIds,
+            ),
+        ).thenReturn(setOf(1L))
         whenever(eventService.getIntegrationStatistics(any(), any()))
             .thenReturn(SliceImpl(listOf(testProjection()), PageRequest.of(0, 20), false))
 
@@ -116,8 +121,14 @@ class HistoryControllerWebMvcTest {
 
     @Test
     fun `integration statistics endpoint returns empty content when user has no authorized source applications`() {
-        whenever(authorizationService.getIntersectionWithAuthorizedSourceApplicationIds(any(), anyOrNull()))
-            .thenReturn(emptySet())
+        val candidateSourceApplicationIds = setOf(1L)
+        whenever(eventService.findDistinctSourceApplicationIds()).thenReturn(candidateSourceApplicationIds)
+        whenever(
+            authorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                candidateSourceApplicationIds,
+            ),
+        ).thenReturn(emptySet())
 
         mockMvc
             .perform(


### PR DESCRIPTION
## Summary

Implements [FFS-2186](https://novari-iks.atlassian.net/browse/FFS-2186).

- Oppgraderer til `flyt-web-resource-server:4.0.0`.
- Autoriserer distinkte kandidat-ID-er i batch før data hentes og returnerer bare tillatte resultater.

[FFS-2186]: https://novari-iks.atlassian.net/browse/FFS-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ