### PR TITLE
FFS-2233 Add OpenTelemetry tracing rollout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     kotlin("jvm") version "2.4.0"
     kotlin("plugin.spring") version "2.4.0"
     kotlin("plugin.jpa") version "2.4.0"
+    kotlin("kapt") version "2.4.0"
 }
 
 group = "no.novari"
@@ -58,13 +59,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.3")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
-    implementation("no.novari:flyt-kafka:7.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:flyt-kafka:7.3.0-rc-2")
     implementation("no.novari:flyt-audit-starter:1.0.0")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
@@ -73,9 +76,11 @@ dependencies {
     compileOnly("org.springframework.security:spring-security-web")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
     runtimeOnly("org.postgresql:postgresql")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-core")
@@ -83,6 +88,7 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.1"))
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation(kotlin("test"))
 }
 
 tasks.withType<Test>().configureEach {

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/afk-no"
       - op: replace

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/afk-no"
       - op: replace
@@ -58,6 +63,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/afk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/agderfk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/agderfk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/agderfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/bfk-no"
       - op: replace
@@ -58,6 +63,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/bfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bym.oslo.kommune.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bym-oslo-kommune-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ffk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/ffk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/fintlabs-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/fintlabs-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/innlandetfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/innlandetfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/mrfylke-no"
       - op: replace

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/nfk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ofk-no"
       - op: replace
@@ -58,6 +63,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/ofk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/rogfk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/rogfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/telemarkfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/telemarkfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/tromsfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/tromsfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/trondelagfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/trondelagfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vestfoldfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/vestfoldfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vlfk-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vlfk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/vlfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -38,6 +38,11 @@ $AUTHORIZED_ORG_ROLE_PAIRS
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "$ORG_ID"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "$SERVLET_CONTEXT_PATH"
       - op: replace
@@ -51,7 +56,7 @@ $AUTHORIZED_ORG_ROLE_PAIRS
         value: "$LIVENESS_PATH"
       - op: replace
         path: "/spec/observability/metrics/path"
-        value: "$METRICS_PATH"
+        value: "$METRICS_PATH"$OTEL_ENV_PATCH
     target:
       kind: Application
       name: fint-flyt-history-service

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -8,6 +8,21 @@ DEFAULT_TEMPLATE="$TEMPLATE_DIR/overlay.yaml.tpl"
 USER_ROLE_URL="USER"
 DEVELOPER_ROLE_URL="DEVELOPER"
 
+OTEL_ENDPOINT_BETA="http://alloy.flais-system.svc.cluster.local:4318"
+
+# Base URL without /v1/traces; telemetry-starter appends the signal path.
+# Set manually until flaiserator supports it, and only in beta where Alloy runs.
+build_otel_env_patch() {
+  local env_path="$1"
+
+  if [[ "$env_path" != "beta" ]]; then
+    return
+  fi
+
+  printf '\n      - op: add\n        path: "/spec/env/-"\n        value:\n          name: "OTEL_EXPORTER_OTLP_ENDPOINT"\n          value: "%s"' \
+    "$OTEL_ENDPOINT_BETA"
+}
+
 extra_user_orgs_for_namespace() {
   local namespace="$1"
   case "$namespace" in
@@ -93,6 +108,7 @@ while IFS= read -r file; do
   export READINESS_PATH="${path_prefix}/actuator/health/readiness"
   export LIVENESS_PATH="${path_prefix}/actuator/health/liveness"
   export METRICS_PATH="${path_prefix}/actuator/prometheus"
+  export OTEL_ENV_PATCH="$(build_otel_env_patch "$env_path")"
   if ((${#additional_user_orgs[@]})); then
     AUTHORIZED_ORG_ROLE_PAIRS="$(render_authorized_role_pairs "$ORG_ID" "${additional_user_orgs[@]}")"
   else
@@ -105,7 +121,7 @@ while IFS= read -r file; do
   target_dir="$ROOT/kustomize/overlays/$dir"
 
   tmp="$(mktemp "$target_dir/.kustomization.yaml.XXXXXX")"
-  envsubst '$NAMESPACE $APP_INSTANCE_LABEL $ORG_ID $KAFKA_TOPIC $INGRESS_BASE_PATH $SERVLET_CONTEXT_PATH $STARTUP_PATH $READINESS_PATH $LIVENESS_PATH $METRICS_PATH $AUTHORIZED_ORG_ROLE_PAIRS $NOVARI_KAFKA_TOPIC_ORGID' \
+  envsubst '$NAMESPACE $APP_INSTANCE_LABEL $ORG_ID $KAFKA_TOPIC $INGRESS_BASE_PATH $SERVLET_CONTEXT_PATH $STARTUP_PATH $READINESS_PATH $LIVENESS_PATH $METRICS_PATH $OTEL_ENV_PATCH $AUTHORIZED_ORG_ROLE_PAIRS $NOVARI_KAFKA_TOPIC_ORGID' \
     < "$template" > "$tmp"
   mv "$tmp" "$target_dir/kustomization.yaml"
 done < <(find "$ROOT/kustomize/overlays" -name kustomization.yaml -print | sort)

--- a/src/main/kotlin/no/novari/flyt/history/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/novari/flyt/history/GlobalExceptionHandler.kt
@@ -1,10 +1,10 @@
 package no.novari.flyt.history
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.history.exceptions.LatestStatusEventNotOfTypeErrorException
 import no.novari.flyt.history.exceptions.NoPreviousStatusEventsFoundException
 import no.novari.flyt.history.exceptions.RequestValidationException
 import no.novari.flyt.history.validation.ValidationErrorsFormattingService
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -18,11 +18,14 @@ import org.springframework.web.server.ResponseStatusException
 class GlobalExceptionHandler(
     private val validationErrorsFormattingService: ValidationErrorsFormattingService,
 ) {
-    private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+    private val logger = KotlinLogging.logger {}
 
     @ExceptionHandler(RequestValidationException::class)
     fun handleRequestValidation(exception: RequestValidationException): ProblemDetail {
-        logger.warn("Request validation failed", exception)
+        logger.atWarn {
+            message = "Request validation failed"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.UNPROCESSABLE_ENTITY,
             title = "Unprocessable Entity",
@@ -32,7 +35,10 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(BindException::class)
     fun handleBindException(exception: BindException): ProblemDetail {
-        logger.warn("Request binding validation failed", exception)
+        logger.atWarn {
+            message = "Request binding validation failed"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.UNPROCESSABLE_ENTITY,
             title = "Unprocessable Entity",
@@ -42,7 +48,10 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadable(exception: HttpMessageNotReadableException): ProblemDetail {
-        logger.warn("Malformed request body", exception)
+        logger.atWarn {
+            message = "Malformed request body"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.UNPROCESSABLE_ENTITY,
             title = "Unprocessable Entity",
@@ -52,7 +61,10 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(NoPreviousStatusEventsFoundException::class)
     fun handleNoPreviousStatusEventsFound(exception: NoPreviousStatusEventsFoundException): ProblemDetail {
-        logger.warn("No previous status event found", exception)
+        logger.atWarn {
+            message = "No previous status event found"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.NOT_FOUND,
             title = "Not Found",
@@ -62,7 +74,10 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(LatestStatusEventNotOfTypeErrorException::class)
     fun handleLatestStatusEventNotOfTypeError(exception: LatestStatusEventNotOfTypeErrorException): ProblemDetail {
-        logger.warn("Latest status event is not of type error", exception)
+        logger.atWarn {
+            message = "Latest status event is not of type error"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.BAD_REQUEST,
             title = "Bad Request",
@@ -72,7 +87,10 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
     fun handleMethodArgumentTypeMismatch(exception: MethodArgumentTypeMismatchException): ProblemDetail {
-        logger.warn("Request parameter type mismatch", exception)
+        logger.atWarn {
+            message = "Request parameter type mismatch"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.BAD_REQUEST,
             title = "Bad Request",
@@ -82,7 +100,11 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(ResponseStatusException::class)
     fun handleResponseStatusException(exception: ResponseStatusException): ProblemDetail {
-        logger.warn("Response status exception with status={}", exception.statusCode, exception)
+        logger.atWarn {
+            message = "Response status exception with status={}"
+            arguments = arrayOf(exception.statusCode)
+            cause = exception
+        }
         return exception.reason
             ?.let { ProblemDetail.forStatusAndDetail(exception.statusCode, it) }
             ?: ProblemDetail.forStatus(exception.statusCode)
@@ -90,7 +112,10 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(Exception::class)
     fun handleUnhandledException(exception: Exception): ProblemDetail {
-        logger.error("Unhandled exception", exception)
+        logger.atError {
+            message = "Unhandled exception"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.INTERNAL_SERVER_ERROR,
             title = "Internal Server Error",

--- a/src/main/kotlin/no/novari/flyt/history/ScheduledErrorScrubService.kt
+++ b/src/main/kotlin/no/novari/flyt/history/ScheduledErrorScrubService.kt
@@ -1,7 +1,7 @@
 package no.novari.flyt.history
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.history.repository.EventRepository
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
@@ -37,7 +37,10 @@ class ScheduledErrorScrubService(
             val scrubbed = transactionTemplate.execute { scrubOneBatch(cutoff) } ?: 0
 
             if (scrubbed == 0) {
-                logger.info("Scheduled error scrub completed; scrubbed {} events older than {}", scrubbedTotal, cutoff)
+                logger.atInfo {
+                    message = "Scheduled error scrub completed; scrubbed {} events older than {}"
+                    arguments = arrayOf(scrubbedTotal, cutoff)
+                }
                 return scrubbedTotal
             }
 
@@ -60,6 +63,6 @@ class ScheduledErrorScrubService(
     }
 
     private companion object {
-        private val logger = LoggerFactory.getLogger(ScheduledErrorScrubService::class.java)
+        private val logger = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/history/metrics/StatisticsMetricsPublisher.kt
+++ b/src/main/kotlin/no/novari/flyt/history/metrics/StatisticsMetricsPublisher.kt
@@ -1,12 +1,12 @@
 package no.novari.flyt.history.metrics
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tags
 import no.novari.flyt.history.EventService
 import no.novari.flyt.history.model.statistics.IntegrationStatisticsFilter
 import no.novari.flyt.history.repository.projections.IntegrationStatisticsProjection
-import org.slf4j.LoggerFactory
 import org.springframework.core.env.Environment
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -46,7 +46,10 @@ class StatisticsMetricsPublisher(
             publishIntegrationTotals(allIntegrations)
             publishSourceApplicationTotals(allIntegrations)
         } catch (exception: Exception) {
-            logger.warn("Failed to refresh statistics metrics", exception)
+            logger.atWarn {
+                message = "Failed to refresh statistics metrics"
+                cause = exception
+            }
         }
     }
 
@@ -206,7 +209,7 @@ class StatisticsMetricsPublisher(
     }
 
     companion object {
-        private val logger = LoggerFactory.getLogger(StatisticsMetricsPublisher::class.java)
+        private val logger = KotlinLogging.logger {}
 
         private const val INSTANCE_METRIC = "flyt.history.instance.count"
         private const val INTEGRATION_METRIC = "flyt.history.integration.count"

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,8 @@ server:
     include-message: always
 
 spring:
+  application:
+    name: ${fint.application-id}
   data:
     web:
       pageable:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>

--- a/src/test/kotlin/no/novari/flyt/history/repository/EventRepositoryPerformanceTest.kt
+++ b/src/test/kotlin/no/novari/flyt/history/repository/EventRepositoryPerformanceTest.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.history.repository
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.history.JpaAuditingTestConfig
 import no.novari.flyt.history.model.event.EventCategorizationService
 import no.novari.flyt.history.model.event.EventCategory
@@ -32,7 +33,6 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -80,7 +80,10 @@ class EventRepositoryPerformanceTest {
 
     @BeforeEach
     fun generateEvents() {
-        log.info("PostgreSQL test container url: {}", postgreSQLContainer.jdbcUrl.split("?")[0])
+        log.atInfo {
+            message = "PostgreSQL test container url: {}"
+            arguments = arrayOf(postgreSQLContainer.jdbcUrl.split("?")[0])
+        }
         if (isInitialized) {
             return
         }
@@ -199,7 +202,10 @@ class EventRepositoryPerformanceTest {
                 pageSizePerformanceTestCase.requestedMaxSize,
             )
         val elapsedTime = timer.elapsedTime
-        log.info("Elapsed time={}", formatDuration(elapsedTime))
+        log.atInfo {
+            message = "Elapsed time={}"
+            arguments = arrayOf(formatDuration(elapsedTime))
+        }
         assertThat(instanceFlowSummaries).hasSize(pageSizePerformanceTestCase.expectedSize)
         assertThat(elapsedTime).isLessThan(pageSizePerformanceTestCase.maxElapsedTime)
     }
@@ -266,7 +272,7 @@ class EventRepositoryPerformanceTest {
                         .withMemory(DataSize.ofGigabytes(8).toBytes())
                 }
 
-        private val log = LoggerFactory.getLogger(EventRepositoryPerformanceTest::class.java)
+        private val log = KotlinLogging.logger {}
         private var isInitialized = false
 
         private val INSTANCE_FLOW_SUMMARIES_QUERY_FILTER_SOURCE_APPLICATION_INSTANCE_ID =

--- a/src/test/kotlin/no/novari/flyt/history/repository/utils/BatchPersister.kt
+++ b/src/test/kotlin/no/novari/flyt/history/repository/utils/BatchPersister.kt
@@ -1,8 +1,8 @@
 package no.novari.flyt.history.repository.utils
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.history.repository.utils.performance.DurationFormatter.formatDuration
 import no.novari.flyt.history.repository.utils.performance.Timer
-import org.slf4j.LoggerFactory
 import org.springframework.data.jpa.repository.JpaRepository
 
 class BatchPersister<T>(
@@ -14,32 +14,41 @@ class BatchPersister<T>(
         val entityBatches = entities.chunked(batchSize)
         val numberOfBatches = entityBatches.size
 
-        log.debug("Persisting {} entities in {} batches of size {}", numberOfEntities, numberOfBatches, batchSize)
+        log.atDebug {
+            message = "Persisting {} entities in {} batches of size {}"
+            arguments = arrayOf(numberOfEntities, numberOfBatches, batchSize)
+        }
         val timer = Timer.start()
 
         entityBatches.forEachIndexed { index, batchEntities ->
             val batchTimer = Timer.start()
             repository.saveAllAndFlush(batchEntities)
             val batchElapsedTime = batchTimer.elapsedTime
-            log.debug(
-                "Persisted batch {} of {} in {} ({}/s)",
-                index + 1,
-                numberOfBatches,
-                formatDuration(batchElapsedTime),
-                ((batchEntities.size.toLong()) * 1000) / batchElapsedTime.toMillis(),
-            )
+            log.atDebug {
+                message = "Persisted batch {} of {} in {} ({}/s)"
+                arguments =
+                    arrayOf(
+                        index + 1,
+                        numberOfBatches,
+                        formatDuration(batchElapsedTime),
+                        ((batchEntities.size.toLong()) * 1000) / batchElapsedTime.toMillis(),
+                    )
+            }
         }
 
         val elapsedTime = timer.elapsedTime
-        log.debug(
-            "Persisted {} entities in {} ({}/s)",
-            numberOfEntities,
-            formatDuration(elapsedTime),
-            String.format("%.2f", numberOfEntities.toDouble() * 1000 / elapsedTime.toMillis()),
-        )
+        log.atDebug {
+            message = "Persisted {} entities in {} ({}/s)"
+            arguments =
+                arrayOf(
+                    numberOfEntities,
+                    formatDuration(elapsedTime),
+                    String.format("%.2f", numberOfEntities.toDouble() * 1000 / elapsedTime.toMillis()),
+                )
+        }
     }
 
     private companion object {
-        private val log = LoggerFactory.getLogger(BatchPersister::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/test/kotlin/no/novari/flyt/history/repository/utils/performance/EventDatasetGenerator.kt
+++ b/src/test/kotlin/no/novari/flyt/history/repository/utils/performance/EventDatasetGenerator.kt
@@ -1,10 +1,10 @@
 package no.novari.flyt.history.repository.utils.performance
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.history.model.event.EventCategory
 import no.novari.flyt.history.repository.entities.EventEntity
 import no.novari.flyt.history.repository.entities.InstanceFlowHeadersEmbeddable
 import no.novari.flyt.history.repository.utils.BatchPersister
-import org.slf4j.LoggerFactory
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.Random
@@ -33,7 +33,10 @@ class EventDatasetGenerator(
         val totalNumberOfConfigs = eventGenerationConfigs.size
         var totalNumberOfEventsGeneratedAndPersisted = 0
 
-        log.info("Generating and persisting {} events from {} configs", totalNumberOfEvents, totalNumberOfConfigs)
+        log.atInfo {
+            message = "Generating and persisting {} events from {} configs"
+            arguments = arrayOf(totalNumberOfEvents, totalNumberOfConfigs)
+        }
         val totalTimer = Timer.start()
 
         eventGenerationConfigs.forEachIndexed { configIndex, eventGenerationConfig ->
@@ -42,7 +45,10 @@ class EventDatasetGenerator(
                     config.eventSequence.size * config.numberOfSequences
                 }
             val configNumber = configIndex + 1
-            log.debug("Generating and persisting {} events from config {}", numberOfEventsFromConfig, configNumber)
+            log.atDebug {
+                message = "Generating and persisting {} events from config {}"
+                arguments = arrayOf(numberOfEventsFromConfig, configNumber)
+            }
 
             val configTimer = Timer.start()
             generateAndPersistEvents(eventGenerationConfig)
@@ -62,29 +68,43 @@ class EventDatasetGenerator(
                     .dividedBy(numberOfEventsFromConfig.toLong())
                     .multipliedBy(totalRemainingEvents.toLong())
 
-            log.info(
-                "Config {}/{}: {} events in {} ({}/s) || Total: {}/{} ({}%) events in {} ({}/s) || Estimated remaining time: {}",
-                String.format("%,${getNumberOfDigits(totalNumberOfConfigs)}d", configNumber),
-                String.format("%,d", totalNumberOfConfigs),
-                String.format("%,${getNumberOfDigits(largestNumberOfEventsPerSequence)}d", numberOfEventsFromConfig),
-                DurationFormatter.formatDuration(configElapsedTime),
-                String.format("%,6.2f", numberOfEventsPerSecondForConfig),
-                String.format("%,${getNumberOfDigits(totalNumberOfEvents)}d", totalNumberOfEventsGeneratedAndPersisted),
-                String.format("%,d", totalNumberOfEvents),
-                String.format("%,.2f", percentageOfTotalEventsProcessed),
-                DurationFormatter.formatDuration(totalElapsedTime),
-                String.format("%,6.2f", numberOfEventsPerSecondTotal),
-                DurationFormatter.formatDuration(estimatedRemainingTime),
-            )
+            log.atInfo {
+                message =
+                    "Config {}/{}: {} events in {} ({}/s) || Total: {}/{} ({}%) events in {} ({}/s) || " +
+                    "Estimated remaining time: {}"
+                arguments =
+                    arrayOf(
+                        String.format("%,${getNumberOfDigits(totalNumberOfConfigs)}d", configNumber),
+                        String.format("%,d", totalNumberOfConfigs),
+                        String.format(
+                            "%,${getNumberOfDigits(largestNumberOfEventsPerSequence)}d",
+                            numberOfEventsFromConfig,
+                        ),
+                        DurationFormatter.formatDuration(configElapsedTime),
+                        String.format("%,6.2f", numberOfEventsPerSecondForConfig),
+                        String.format(
+                            "%,${getNumberOfDigits(totalNumberOfEvents)}d",
+                            totalNumberOfEventsGeneratedAndPersisted,
+                        ),
+                        String.format("%,d", totalNumberOfEvents),
+                        String.format("%,.2f", percentageOfTotalEventsProcessed),
+                        DurationFormatter.formatDuration(totalElapsedTime),
+                        String.format("%,6.2f", numberOfEventsPerSecondTotal),
+                        DurationFormatter.formatDuration(estimatedRemainingTime),
+                    )
+            }
         }
 
         val elapsedTime = totalTimer.elapsedTime
-        log.info(
-            "Generated and persisted {} events in {} ({}/s)",
-            totalNumberOfEvents,
-            DurationFormatter.formatDuration(elapsedTime),
-            String.format("%.2f", totalNumberOfEvents.toDouble() * 1000 / elapsedTime.toMillis()),
-        )
+        log.atInfo {
+            message = "Generated and persisted {} events in {} ({}/s)"
+            arguments =
+                arrayOf(
+                    totalNumberOfEvents,
+                    DurationFormatter.formatDuration(elapsedTime),
+                    String.format("%.2f", totalNumberOfEvents.toDouble() * 1000 / elapsedTime.toMillis()),
+                )
+        }
     }
 
     fun generateEvent(
@@ -211,6 +231,6 @@ class EventDatasetGenerator(
     }
 
     private companion object {
-        private val log = LoggerFactory.getLogger(EventDatasetGenerator::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }


### PR DESCRIPTION
## Summary

- Roll out OpenTelemetry tracing support for HTTP and Kafka by adding `telemetry-starter`, updating the FLYT web resource server and Kafka libraries, and enabling Kafka tracing.
- Configure `spring.application.name`, structured JSON logging with trace context, and app-level telemetry org-id environment variables.
- Extend the generated kustomize overlay template/script so beta overlays get `OTEL_EXPORTER_OTLP_ENDPOINT` while API overlays only get the telemetry org-id.
- Convert existing SLF4J usage to `kotlin-logging`.

## Context

Jira: https://novari-iks.atlassian.net/browse/FFS-2233

This follows the rollout pattern from FFS-2196 and uses `telemetry-starter:0.0.4`, which includes the actuator exclusion fix.

## Validation

- Verified current artifact versions in `repo.fintlabs.no/releases` before changing dependencies.
- Regenerated kustomize overlays with `./script/render-overlay.sh`.
- Ran `kustomize build` for all overlays.
- Ran `./gradlew check`.