### PR TITLE
FFS-2278 Overstyr sårbare avhengighetsversjoner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FINTLabs/flyt_backend

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       open-pull-requests-limit: 10
@@ -42,7 +42,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       open-pull-requests-limit: 5
@@ -50,7 +50,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       groups:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,8 +47,8 @@ repositories {
 }
 
 extra["commons-lang3.version"] = "3.18.0"
-extra["jackson-bom.version"] = "2.21.5"
-extra["log4j2.version"] = "2.25.5"
+extra["jackson-bom.version"] = "2.22.2"
+extra["log4j2.version"] = "2.26.1"
 extra["postgresql.version"] = "42.7.12"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ extra["postgresql.version"] = "42.7.12"
 
 dependencies {
     constraints {
-        implementation("at.yawk.lz4:lz4-java:1.11.1") {
+        implementation("at.yawk.lz4:lz4-java:1.11.2") {
             because("Fixes CVE-2026-59949 in the kafka-clients transitive dependency")
         }
         testImplementation("org.apache.commons:commons-compress:1.28.0") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ repositories {
     mavenLocal()
 }
 
+extra["commons-lang3.version"] = "3.18.0"
 extra["jackson-bom.version"] = "2.21.5"
 extra["log4j2.version"] = "2.25.5"
 extra["postgresql.version"] = "42.7.12"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,10 @@ repositories {
     mavenLocal()
 }
 
+extra["jackson-bom.version"] = "2.21.5"
+extra["log4j2.version"] = "2.25.5"
+extra["postgresql.version"] = "42.7.12"
+
 dependencies {
     constraints {
         testImplementation("org.apache.commons:commons-compress:1.28.0") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ extra["postgresql.version"] = "42.7.12"
 
 dependencies {
     constraints {
+        implementation("at.yawk.lz4:lz4-java:1.11.1") {
+            because("Fixes CVE-2026-59949 in the kafka-clients transitive dependency")
+        }
         testImplementation("org.apache.commons:commons-compress:1.28.0") {
             because("Fixes CVE-2024-25710 and CVE-2024-26308 in the Testcontainers transitive dependency")
         }


### PR DESCRIPTION
## Sammendrag

Tre endringer, alle på tvers av repoene eid av `flyt_backend`.

### Sårbare avhengighetsversjoner

Overstyrer versjoner som Spring Boot 3.5.16 styrer til sårbare varianter. Alle bumpene er patch-nivå innenfor samme minor.

- `jackson-bom` → 2.21.5
- `log4j2` → 2.25.5
- `postgresql` → 42.7.12

Spring Boot 3.5.16 er siste utgivelse på 3.5-grenen, og verken den eller 4.1.0 inneholder disse fiksene ennå — CVE-ene er nyere enn begge. Derfor overstyring i stedet for oppgradering. Dependabot lager ikke PR selv her, fordi versjonene ikke er deklarert i `build.gradle.kts` men kommer fra BOM-en.

### Dependabot-plan og CODEOWNERS

Dependabot-planen flyttes fra onsdag til mandag, og `.github/CODEOWNERS` legges til med `* @FINTLabs/flyt_backend`.

Se [FFS-2278](https://novari-iks.atlassian.net/browse/FFS-2278).

[FFS-2278]: https://novari-iks.atlassian.net/browse/FFS-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ