### PR TITLE
FFS-2253 Utsett scrubbing av feilmeldinger til retention-jobben

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     kotlin("jvm") version "2.4.10"
     kotlin("plugin.spring") version "2.4.10"
     kotlin("plugin.jpa") version "2.4.10"
+    kotlin("kapt") version "2.4.10"
 }
 
 group = "no.novari"
@@ -84,6 +85,7 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-core")
@@ -91,6 +93,7 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.5"))
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation(kotlin("test"))
 }
 
 tasks.withType<Test>().configureEach {

--- a/src/main/kotlin/no/novari/flyt/history/kafka/InstanceDeletedConsumerConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/history/kafka/InstanceDeletedConsumerConfiguration.kt
@@ -24,8 +24,9 @@ class InstanceDeletedConsumerConfiguration(
         return instanceFlowListenerFactoryService
             .createRecordListenerContainerFactory(
                 Any::class.java,
-                { instanceFlowConsumerRecord ->
-                    errorScrubService.scrubByInstanceFlowHeaders(instanceFlowConsumerRecord.instanceFlowHeaders)
+                { _ ->
+                    // Midlertidig deaktivert: umiddelbar scrubbing ved instance-deleted er skrudd av.
+                    // Scrubbing skjer nå kun via ScheduledErrorScrubService (etter retention-perioden).
                 },
                 ListenerConfiguration
                     .stepBuilder()

--- a/src/test/kotlin/no/novari/flyt/history/kafka/InstanceDeletedConsumerConfigurationTest.kt
+++ b/src/test/kotlin/no/novari/flyt/history/kafka/InstanceDeletedConsumerConfigurationTest.kt
@@ -113,7 +113,7 @@ class InstanceDeletedConsumerConfigurationTest {
     }
 
     @Test
-    fun `consumer scrubs matching events and leaves scrubbed timestamp unchanged on repeated consume`() {
+    fun `consumer does not scrub events on instance-deleted while immediate scrubbing is disabled`() {
         val matchingHeaders = headers(1L, "sa-integration-1", "sa-instance-1")
         val firstMatchingError =
             errorEvent(
@@ -141,50 +141,19 @@ class InstanceDeletedConsumerConfigurationTest {
                 name = EventCategory.INSTANCE_REGISTERED.eventName,
                 timestamp = odt(2024, 1, 1, 12, 2),
             )
-        val otherError =
-            errorEvent(
-                sourceApplicationId = 2L,
-                sourceApplicationIntegrationId = "sa-integration-2",
-                sourceApplicationInstanceId = "sa-instance-2",
-                name = EventCategory.INSTANCE_RECEIVAL_ERROR.eventName,
-                timestamp = odt(2024, 1, 1, 12, 3),
-                args = mapOf("filename" to "keep-me.pdf"),
-            )
 
-        eventRepository.saveAllAndFlush(listOf(firstMatchingError, secondMatchingError, matchingInfo, otherError))
+        eventRepository.saveAllAndFlush(listOf(firstMatchingError, secondMatchingError, matchingInfo))
 
         listener.accept(instanceDeletedConsumerRecord(matchingHeaders))
 
-        val matchingEventIds = listOf(firstMatchingError.id, secondMatchingError.id, matchingInfo.id)
+        val eventIds = listOf(firstMatchingError.id, secondMatchingError.id, matchingInfo.id)
 
-        matchingEventIds.forEach { eventId ->
-            assertThat(isScrubbed(eventId)).isTrue()
-            assertThat(scrubbedAt(eventId)).isNotNull()
+        eventIds.forEach { eventId ->
+            assertThat(isScrubbed(eventId)).isFalse()
+            assertThat(scrubbedAt(eventId)).isNull()
         }
-        assertThat(errorArgValues(firstMatchingError.id)).containsExactly("", "")
-        assertThat(errorArgValues(secondMatchingError.id)).containsExactly("")
-        assertThat(isScrubbed(otherError.id)).isFalse()
-        assertThat(scrubbedAt(otherError.id)).isNull()
-        assertThat(errorArgValues(otherError.id)).containsExactly("keep-me.pdf")
-
-        val scrubbedAtBeforeSecondConsume =
-            matchingEventIds.associateWith { eventId ->
-                requireNotNull(scrubbedAt(eventId))
-            }
-
-        Thread.sleep(20)
-        listener.accept(instanceDeletedConsumerRecord(matchingHeaders))
-
-        val scrubbedAtAfterSecondConsume =
-            matchingEventIds.associateWith { eventId ->
-                requireNotNull(scrubbedAt(eventId))
-            }
-
-        assertThat(scrubbedAtAfterSecondConsume).isEqualTo(scrubbedAtBeforeSecondConsume)
-        assertThat(errorArgValues(firstMatchingError.id)).containsExactly("", "")
-        assertThat(errorArgValues(secondMatchingError.id)).containsExactly("")
-        assertThat(isScrubbed(otherError.id)).isFalse()
-        assertThat(errorArgValues(otherError.id)).containsExactly("keep-me.pdf")
+        assertThat(errorArgValues(firstMatchingError.id)).containsExactly("document.pdf", "bad-payload")
+        assertThat(errorArgValues(secondMatchingError.id)).containsExactly("archive-123")
     }
 
     @Test


### PR DESCRIPTION
## Sammendrag
- Skrur midlertidig av umiddelbar scrubbing av feilmeldinger som skjedde når en instans gikk gjennom (instance-deleted-consumeren)
- Feilmeldinger scrubbes nå kun via den planlagte retention-jobben (`ScheduledErrorScrubService`), som allerede kjører med 60 dagers oppbevaringstid
- Dette er en midlertidig løsning